### PR TITLE
Keep the caller's sample buffer when the sample rate changes

### DIFF
--- a/src/eci_env.c
+++ b/src/eci_env.c
@@ -479,9 +479,23 @@ int32_t STDCALL ev_setParam(OldInst *h, int32_t which, int32_t value)
         v = (value == 1) ? 0 : 1;
 
     if (which == ENV_RATE) {
-        if (ev_setOutputToDevice(inst, value, OI_ENV(inst)[13],
-                                 OI_ENV(inst)[14], OI_ENV(inst)[15],
-                                 OI_ENV(inst)[16]))
+        /* Wherever the samples are going now, they have to go on going
+           there. Rebuilding as a device regardless, which is what IBM's
+           engine does, loses a buffer registered with eciSetOutputBuffer:
+           ev_setOutputToDevice hands the engine a null one on its way past
+           WHERE_SAMPLES, and the instance reports the new rate ever after and
+           answers no more samples. ev_sendChangedEnvironment has always
+           chosen on OI_WHERE; this is the same choice. */
+        int made = 1;
+
+        if (OI_WHERE(inst) == WHERE_DEVICE)
+            made = ev_setOutputToDevice(inst, value, OI_ENV(inst)[13],
+                                        OI_ENV(inst)[14], OI_ENV(inst)[15],
+                                        OI_ENV(inst)[16]);
+        else if (OI_WHERE(inst) == WHERE_SAMPLES)
+            made = ev_setOutputToSampleCallback(inst, value);
+
+        if (made)
             OI_ENV(inst)[which] = value;
         else
             old = -1;


### PR DESCRIPTION
`eciSetParam(eciSampleRate, ...)` leaves an instance that had registered a
buffer with `eciSetOutputBuffer` silent for the rest of its life.

`ev_setParam` rebuilt the output as a device whatever it had been, and
`ev_setOutputToDevice` hands the engine a null buffer on its way past
`WHERE_SAMPLES` -- so the caller's buffer is forgotten. The instance goes on
reporting the new rate quite happily and never answers another sample.
Setting the rate back does not recover it, because that loses the buffer a
second time, and neither does setting it to the value it already has.

`ev_sendChangedEnvironment` has always chosen what to rebuild by looking at
`OI_WHERE`. This makes `ev_setParam` make the same choice.

Before, six rate changes on one instance:

```
  asked 1 -> 11025 Hz        0 samples  SILENT
  asked 0 ->  8000 Hz        0 samples  SILENT
  asked 1 -> 11025 Hz        0 samples  SILENT
  asked 0 ->  8000 Hz        0 samples  SILENT
  asked 2 -> 22050 Hz        0 samples  SILENT
  asked 1 -> 11025 Hz        0 samples  SILENT
```

After:

```
  asked 1 -> 11025 Hz    19371 samples  1.76 s  ok
  asked 0 ->  8000 Hz    14088 samples  1.76 s  ok
  asked 1 -> 11025 Hz    19371 samples  1.76 s  ok
  asked 0 ->  8000 Hz    14088 samples  1.76 s  ok
  asked 2 -> 22050 Hz    19371 samples  0.88 s  ok
  asked 1 -> 11025 Hz    19371 samples  1.76 s  ok
```

The audio is otherwise unchanged: identical SHA-256 over three voices and
seven texts.

Rate 2 answering 11025's sample count is a separate thing and is not touched
here -- it is the second half of #2's comment.

Found while writing an NVDA driver, where changing the sample rate setting
killed the synthesiser until NVDA was restarted.