### PR TITLE
Write the rules out over several files, so RULES=c can be built 32-bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ __pycache__/
 
 # Thirteen megabytes written out of the transcription beside it by
 # tools/delta-decompile.py, and rewritten whole by every change to that tool.
-# `make rules' makes it.
+# `make rules' makes it, spread over the numbered pieces beside it.
 lang/enus/delta_rules_c.c
+lang/enus/delta_rules_c_*.c

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,19 @@ NM  ?= nm
 RULES ?= bytecode
 
 GENERATED := $(LANG)/delta_rules_c.c
+# The rules are written out over several files rather than one. All of them
+# together are thirteen megabytes, and a thirty-two bit compiler runs out of
+# address space on a single file that size, so RULES=c could not be built
+# thirty-two bit at all. Split, each piece is small enough for one, and a
+# make -j compiles them at the same time as each other.
+RULE_PARTS ?= 16
+GENERATED_PARTS := $(wildcard $(LANG)/delta_rules_c_*.c)
 STUB      := $(SRC)/delta_rules_none.c
 
 ifeq ($(RULES),bytecode)
 RULESRC := $(STUB)
 else ifeq ($(RULES),c)
-RULESRC := $(GENERATED)
+RULESRC := $(GENERATED) $(GENERATED_PARTS)
 else
 $(error RULES is bytecode or c, not $(RULES))
 endif
@@ -50,7 +57,8 @@ endif
 # porting layer and belongs to the reference build; the two rule tables are
 # chosen between above rather than both linked.
 SOURCES := $(filter-out $(SRC)/port_win32.c $(STUB),$(wildcard $(SRC)/*.c)) \
-           $(filter-out $(GENERATED),$(sort $(wildcard $(LANG)/*.c))) \
+           $(filter-out $(GENERATED) $(GENERATED_PARTS),\
+                        $(sort $(wildcard $(LANG)/*.c))) \
            $(RULESRC)
 
 # Every header, because a struct that changed shape and an object that was
@@ -87,7 +95,7 @@ ALL_CFLAGS := $(OPT) -std=gnu99 -I$(SRC) -I$(LANG) $(WARN) $(LOW) $(CFLAGS)
 OBJDIR  := $(BUILD)/obj
 OBJECTS := $(patsubst %.c,$(OBJDIR)/%.o,$(notdir $(SOURCES)))
 
-.PHONY: all probe rules missing install clean evv32 probe32
+.PHONY: all probe rules missing install clean distclean evv32 probe32
 all: $(BUILD)/evv
 
 $(BUILD)/evv: cli/evv.c $(BUILD)/libevv.a
@@ -122,7 +130,7 @@ rules: $(GENERATED)
 
 $(GENERATED): $(LANG)/delta_rules_enus.c $(LANG)/delta_consts_enus.c \
               tools/delta-decompile.py tools/delta-census.py
-	@python3 tools/delta-decompile.py all
+	@python3 tools/delta-decompile.py all --parts=$(RULE_PARTS)
 
 # What our code asks for and nothing of ours answers. The C library's own
 # names are dropped, since those come from the system; what is left is the
@@ -130,6 +138,12 @@ $(GENERATED): $(LANG)/delta_rules_enus.c $(LANG)/delta_consts_enus.c \
 missing: $(OBJECTS)
 	@$(NM) $(OBJECTS) > $(BUILD)/syms.txt
 	@python3 tools/missing.py $(BUILD)/syms.txt
+
+# The pieces the rules were written out over go too. A later run that made
+# fewer of them would otherwise leave the extra ones to be compiled, and they
+# would define their rules a second time.
+distclean: clean
+	@rm -f $(GENERATED) $(LANG)/delta_rules_c_*.c
 
 clean:
 	@rm -rf $(OBJDIR) $(OBJDIR32) $(OBJDIRWIN) $(OBJDIRWIN32) \
@@ -202,7 +216,8 @@ CFLAGSWIN  := $(OPT) -std=gnu99 -I$(SRC) -I$(LANG) $(WARN) -DEVV_ARENA=1 \
 LDFLAGSWIN := -static $(MINGW64_LDFLAGS)
 
 SOURCESWIN := $(filter-out $(SRC)/port_posix.c $(STUB),$(wildcard $(SRC)/*.c)) \
-              $(filter-out $(GENERATED),$(sort $(wildcard $(LANG)/*.c))) \
+              $(filter-out $(GENERATED) $(GENERATED_PARTS),\
+                           $(sort $(wildcard $(LANG)/*.c))) \
               $(RULESRC)
 OBJECTSWIN := $(patsubst %.c,$(OBJDIRWIN)/%.o,$(notdir $(SOURCESWIN)))
 

--- a/src/eci_env.c
+++ b/src/eci_env.c
@@ -479,9 +479,26 @@ int32_t STDCALL ev_setParam(OldInst *h, int32_t which, int32_t value)
         v = (value == 1) ? 0 : 1;
 
     if (which == ENV_RATE) {
-        if (ev_setOutputToDevice(inst, value, OI_ENV(inst)[13],
-                                 OI_ENV(inst)[14], OI_ENV(inst)[15],
-                                 OI_ENV(inst)[16]))
+        /* Wherever the samples are going now, they have to go on going
+           there. Rebuilding as a device regardless is what this did before,
+           and for a caller that had registered a buffer with
+           eciSetOutputBuffer that was quietly fatal: ev_setOutputToDevice
+           hands the engine a null buffer on its way past WHERE_SAMPLES and
+           forgets the caller's, so the instance went on saying it was at the
+           new rate and never answered another sample. Nothing failed and
+           eciGetParam read back correctly, which is what made it hard to
+           see. ev_sendChangedEnvironment has always chosen on OI_WHERE; this
+           is the same choice. */
+        int made = 1;
+
+        if (OI_WHERE(inst) == WHERE_DEVICE)
+            made = ev_setOutputToDevice(inst, value, OI_ENV(inst)[13],
+                                        OI_ENV(inst)[14], OI_ENV(inst)[15],
+                                        OI_ENV(inst)[16]);
+        else if (OI_WHERE(inst) == WHERE_SAMPLES)
+            made = ev_setOutputToSampleCallback(inst, value);
+
+        if (made)
             OI_ENV(inst)[which] = value;
         else
             old = -1;

--- a/tools/delta-decompile.py
+++ b/tools/delta-decompile.py
@@ -347,10 +347,65 @@ HEAD = """\
 """
 
 
-def write(names):
-    done, refused = [], []
-    text = [HEAD]
+def rule_text(name, rule, row, body):
+    """One rule as C, ready to be written into whichever file it belongs to."""
+    out = []
+    _n, _o, _s, _l = row
+    frame, pbase, params = c_rule_shape(name)
+    out.append('/* %s, from %s */\n' % (name, rule.obj))
+    out.append('int32_t evv_%s(void *state, const int32_t *args,'
+               ' int nargs)\n{\n' % name)
+    # The frame is not an ordinary local. A rule hands the machine the
+    # address of it, and where a value is 32 bits and an address is not,
+    # the only stack that can be named in one is the arena's.
+    out.append('    unsigned char *frame = evv_frame_push('
+               'DELTA_RULE_FRAME_MAX);\n')
+    out.append('    unsigned char *base = frame + %d;\n' % frame)
+    out.append('    unsigned char *param = base + %d;\n' % pbase)
+    out.append('    int32_t arg[%d];\n' % MAXARG)
+    # A landing from a backtrack comes back into the middle of the
+    # function, and anything the compiler had chosen to keep in a machine
+    # register would come back stale. The interpreter is safe because
+    # everything it needs lives in a block whose address has escaped; here
+    # the frame and the argument area are addressed, and the rest is said
+    # to be volatile so that it is not kept anywhere else.
+    out.append('    volatile int argn = 0;\n')
+    out.append('    volatile int32_t r0 = 0, r1 = 0, r2 = 0, r3 = 0,'
+               ' r4 = 0, r5 = 0, r6 = 0, r7 = 0;\n')
+    out.append('    delta_flags fl;\n')
+    out.append('    int i;\n\n')
+    out.append('    memset(frame, 0, DELTA_RULE_FRAME_MAX);\n')
+    out.append('    memset(arg, 0, sizeof arg);\n')
+    out.append('    memset(&fl, 0, sizeof fl);\n')
+    out.append('    for (i = 0; i < nargs && i < %d; i++)\n' % params)
+    out.append('        memcpy(base + %d + 4 * i, &args[i], 4);\n\n' % pbase)
+    # Taking the dead loads out first brings more calls up against
+    # their arguments, which is why the joining goes last.
+    named, saw = name_globals(
+        join_calls(rule.c, join_pops(drop_dead(structure(fold(body))))))
+    named = name_alternatives(name_params(named, pbase, params))
+    USED.update(saw)
+    out.append('\n'.join(named))
+    tail = ('' if named and named[-1].strip().endswith('return out; }')
+            else '\n    evv_frame_pop(frame);\n    return r0;')
+    out.append('%s\n}\n\n' % tail)
+    return out
 
+
+def globals_text():
+    """Where each global the rules reach through lands in the state."""
+    if not USED:
+        return ''
+    where = {v: k for k, v in layout().items()}
+    return ('/* Where each global the rules touch lands in the state. */\n'
+            '%s\n\n'
+            % '\n'.join('#define DG_%-6s %5d' % (v, where[v])
+                        for v in sorted(USED, key=lambda x: where[x])))
+
+
+def load_all(names):
+    """Decompile every rule that can be, and say which could not."""
+    kept, refused = [], []
     for name in names:
         try:
             c, index, row, insns = load(name)
@@ -359,66 +414,107 @@ def write(names):
         except Unhandled as why:
             refused.append((name, str(why)))
             continue
+        kept.append((name, rule, row, body))
+    return kept, refused
 
-        _n, _o, _s, _l = row
-        frame, pbase, params = c_rule_shape(name)
-        text.append('/* %s, from %s */\n' % (name, rule.obj))
-        text.append('static int32_t evv_%s(void *state, const int32_t *args,'
-                    ' int nargs)\n{\n' % name)
-        # The frame is not an ordinary local. A rule hands the machine the
-        # address of it, and where a value is 32 bits and an address is not,
-        # the only stack that can be named in one is the arena's.
-        text.append('    unsigned char *frame = evv_frame_push('
-                    'DELTA_RULE_FRAME_MAX);\n')
-        text.append('    unsigned char *base = frame + %d;\n' % frame)
-        text.append('    unsigned char *param = base + %d;\n' % pbase)
-        text.append('    int32_t arg[%d];\n' % MAXARG)
-        # A landing from a backtrack comes back into the middle of the
-        # function, and anything the compiler had chosen to keep in a machine
-        # register would come back stale. The interpreter is safe because
-        # everything it needs lives in a block whose address has escaped; here
-        # the frame and the argument area are addressed, and the rest is said
-        # to be volatile so that it is not kept anywhere else.
-        text.append('    volatile int argn = 0;\n')
-        text.append('    volatile int32_t r0 = 0, r1 = 0, r2 = 0, r3 = 0,'
-                    ' r4 = 0, r5 = 0, r6 = 0, r7 = 0;\n')
-        text.append('    delta_flags fl;\n')
-        text.append('    int i;\n\n')
-        text.append('    memset(frame, 0, DELTA_RULE_FRAME_MAX);\n')
-        text.append('    memset(arg, 0, sizeof arg);\n')
-        text.append('    memset(&fl, 0, sizeof fl);\n')
-        text.append('    for (i = 0; i < nargs && i < %d; i++)\n' % params)
-        text.append('        memcpy(base + %d + 4 * i, &args[i], 4);\n\n'
-                    % pbase)
-        # Taking the dead loads out first brings more calls up against
-        # their arguments, which is why the joining goes last.
-        named, saw = name_globals(
-            join_calls(c, join_pops(drop_dead(structure(fold(body))))))
-        named = name_alternatives(name_params(named, pbase, params))
-        USED.update(saw)
-        text.append('\n'.join(named))
-        tail = ('' if named and named[-1].strip().endswith('return out; }')
-                else '\n    evv_frame_pop(frame);\n    return r0;')
-        text.append('%s\n}\n\n' % tail)
+
+def write(names):
+    kept, refused = load_all(names)
+    text = [HEAD]
+    done = []
+    for name, rule, row, body in kept:
+        text.extend(rule_text(name, rule, row, body))
         done.append(name)
-
-    if USED:
-        where = {v: k for k, v in layout().items()}
-        text.insert(1, '/* Where each global the rules touch lands in the'
-                    ' state. */\n%s\n\n'
-                    % '\n'.join('#define DG_%-6s %5d' % (v, where[v])
-                                for v in sorted(USED,
-                                                key=lambda x: where[x])))
+    text.insert(1, globals_text())
     text.append('const delta_rule_c delta_rule_native[] = {\n')
     for name in done:
         text.append('    { %d, evv_%s },\n' % (index_of(name), name))
     text.append('    { -1, 0 },\n};\n')
-
     open(OUT_C, 'w').write(''.join(text))
+    clear_parts(0)
     return done, refused
 
 
 SHAPES = {}
+
+
+def part_path(number):
+    """Where the *number*th piece of the rules goes."""
+    root, ext = os.path.splitext(OUT_C)
+    return '%s_%02d%s' % (root, number, ext)
+
+
+def clear_parts(first):
+    """Remove pieces left behind by a run that made more of them.
+
+    One left over would still be compiled, and would define its rules a
+    second time.
+    """
+    number = first
+    while os.path.exists(part_path(number)):
+        os.remove(part_path(number))
+        number += 1
+
+
+def write_parts(names, parts):
+    """The rules as C, spread over *parts* files instead of one.
+
+    All of them in one file is thirteen megabytes, and a thirty-two bit
+    compiler runs out of address space on that -- at -O1 as much as at -O2 --
+    so the rules cannot be compiled at all for a thirty-two bit host. Split,
+    each piece is small enough for one, and a build with several cores gets
+    to compile them at the same time as each other.
+
+    The rules are linkable rather than static here, because the table that
+    names them is in another file. That file is the one the Makefile already
+    knows about, and it carries the globals and a declaration for each rule
+    as well.
+    """
+    kept, refused = load_all(names)
+    done, written = [], []
+
+    # Written out first, so that they can be shared out by how big they are
+    # rather than by how many there are. The rules are nothing like the same
+    # size -- dividing them evenly by count put a quarter of the whole
+    # thirteen megabytes into one file, which is the thing this is here to
+    # avoid.
+    emitted = [(name, ''.join(rule_text(name, rule, row, body)))
+               for name, rule, row, body in kept]
+    target = max(1, sum(len(t) for _, t in emitted) // parts)
+    # Every piece needs the offsets, because every piece has rules that reach
+    # through them. USED is complete by now, all the rules having been
+    # written out above, so the same block goes at the head of each.
+    globals_block = globals_text()
+
+    text, size, number = [HEAD, globals_block], 0, 0
+    for name, chunk in emitted:
+        # A rule is never split across files, so one enormous rule makes its
+        # own file large; what matters is that the others are not piled on
+        # top of it.
+        if size and size + len(chunk) > target:
+            open(part_path(number), 'w').write(''.join(text))
+            written.append(part_path(number))
+            number += 1
+            text, size = [HEAD, globals_block], 0
+        text.append(chunk)
+        size += len(chunk)
+        done.append(name)
+    if size:
+        open(part_path(number), 'w').write(''.join(text))
+        written.append(part_path(number))
+
+    head = [HEAD, globals_block]
+    for name in done:
+        head.append('int32_t evv_%s(void *state, const int32_t *args,'
+                    ' int nargs);\n' % name)
+    head.append('\nconst delta_rule_c delta_rule_native[] = {\n')
+    for name in done:
+        head.append('    { %d, evv_%s },\n' % (index_of(name), name))
+    head.append('    { -1, 0 },\n};\n')
+    open(OUT_C, 'w').write(''.join(head))
+
+    clear_parts(len(written))
+    return done, refused, written
 
 
 def c_rule_shape(name):
@@ -1021,6 +1117,18 @@ def _enter(body, i):
 
 
 def main():
+    # How many files to spread the rules over. One is what this always did;
+    # more is what lets a thirty-two bit compiler cope with them at all, and
+    # what lets a build with several cores compile them at once.
+    parts = 1
+    argv = list(sys.argv[1:])
+    for i, a in enumerate(argv):
+        if a.startswith('--parts='):
+            parts = max(1, int(a.split('=', 1)[1]))
+            del argv[i]
+            break
+    sys.argv[1:] = argv
+
     if len(sys.argv) > 1 and sys.argv[1] == 'all':
         names = every()
     elif len(sys.argv) > 1 and not sys.argv[1].isdigit():
@@ -1028,7 +1136,11 @@ def main():
     else:
         names = smallest(int(sys.argv[1]) if len(sys.argv) > 1 else 100)
 
-    done, refused = write(names)
+    if parts > 1:
+        done, refused, written = write_parts(names, parts)
+    else:
+        done, refused = write(names)
+        written = []
     print('calls joined to their arguments: %d' % JOINED[0])
     print('wrappers inlined to the primitive they stand for: %d' % WRAPPED[0])
     print('reaches through the state named as the variable they are: %d over %d variables' % (NAMED[0], len(USED)))
@@ -1041,8 +1153,13 @@ def main():
           % (STRUCTURED[0], LOOPED[0]))
     print('landing places folded: %d, entries folded: %d'
           % (FOLDED[0], FOLDED[1]))
-    print('%d of %d rules written to %s'
-          % (len(done), len(names), os.path.relpath(OUT_C, ROOT)))
+    if written:
+        print('%d of %d rules written to %s and %d files beside it'
+              % (len(done), len(names), os.path.relpath(OUT_C, ROOT),
+                 len(written)))
+    else:
+        print('%d of %d rules written to %s'
+              % (len(done), len(names), os.path.relpath(OUT_C, ROOT)))
     if refused:
         seen = {}
         for name, why in refused:

--- a/tools/engine_probe.c
+++ b/tools/engine_probe.c
@@ -1,0 +1,89 @@
+/* Speak one line through whichever eci.dll is named, and say what came back.
+ *
+ * Built for both word sizes so that OpenEVV's library and IBM's original --
+ * which is thirty-two bit and always will be -- can be asked the same thing
+ * and their answers held against each other.
+ *
+ *     engine_probe <path to eci.dll> <text>
+ *
+ * Prints the number of samples and a checksum of them.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+
+typedef void *(__stdcall *NewFn)(void);
+typedef int   (__stdcall *DeleteFn)(void *);
+typedef int   (__stdcall *AddTextFn)(void *, const char *);
+typedef int   (__stdcall *IndexFn)(void *, int);
+typedef int   (__stdcall *SynthFn)(void *);
+typedef int   (__stdcall *SyncFn)(void *);
+typedef int   (__stdcall *BufFn)(void *, int, short *);
+typedef int   (__stdcall *ParamFn)(void *, int, int);
+typedef void  (__stdcall *CbFn)(void *, void *, void *);
+
+#define SAMPLES 2048
+static short buffer[SAMPLES];
+static long  total;
+static unsigned long sum;
+
+static int __stdcall callback(void *h, int msg, long param, void *data)
+{
+    long i;
+    (void)h; (void)data;
+    if (msg == 0) {
+        for (i = 0; i < param; ++i)
+            sum = sum * 1000003u + (unsigned short)buffer[i];
+        total += param;
+    }
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    HMODULE lib;
+    void *h;
+    char dir[MAX_PATH], *slash;
+
+    if (argc < 3) {
+        fprintf(stderr, "usage: engine_probe <eci.dll> <text>\n");
+        return 2;
+    }
+    /* The original wants its .syn files, which it looks for beside itself. */
+    strncpy(dir, argv[1], MAX_PATH - 1);
+    dir[MAX_PATH - 1] = 0;
+    slash = strrchr(dir, 92);      /* a backslash, written as its code */
+    if (!slash) slash = strrchr(dir, '/');
+    if (slash) { *slash = 0; SetCurrentDirectoryA(dir); }
+
+    lib = LoadLibraryA(argv[1]);
+    if (!lib) { fprintf(stderr, "could not load %s (%lu)\n", argv[1], GetLastError()); return 1; }
+
+#define GET(t, n) (t)GetProcAddress(lib, n)
+    NewFn      eciNew      = GET(NewFn, "eciNew");
+    DeleteFn   eciDelete   = GET(DeleteFn, "eciDelete");
+    AddTextFn  eciAddText  = GET(AddTextFn, "eciAddText");
+    IndexFn    eciIndex    = GET(IndexFn, "eciInsertIndex");
+    SynthFn    eciSynth    = GET(SynthFn, "eciSynthesize");
+    SyncFn     eciSync     = GET(SyncFn, "eciSynchronize");
+    BufFn      eciBuf      = GET(BufFn, "eciSetOutputBuffer");
+    ParamFn    eciParam    = GET(ParamFn, "eciSetParam");
+    CbFn       eciCb       = GET(CbFn, "eciRegisterCallback");
+    if (!eciNew || !eciAddText || !eciSynth || !eciBuf || !eciCb) {
+        fprintf(stderr, "%s is missing entry points\n", argv[1]); return 1;
+    }
+
+    h = eciNew();
+    if (!h) { fprintf(stderr, "eciNew failed\n"); return 1; }
+    eciCb(h, (void *)callback, NULL);
+    eciBuf(h, SAMPLES, buffer);
+    eciParam(h, 1, 1);                       /* annotations on */
+    eciAddText(h, argv[2]);
+    eciIndex(h, 0xFFFF);
+    eciSynth(h);
+    eciSync(h);
+    printf("%ld %08lx\n", total, sum);
+    eciDelete(h);
+    return 0;
+}


### PR DESCRIPTION
`RULES=c` cannot be built for a thirty-two bit host at all:

```
cc1.exe: out of memory allocating 234168 bytes
make: *** [Makefile:309: build/objwin32/delta_rules_c.o] Error 1
```

All 3377 rules go into one file of 12.9 MB and a thirty-two bit compiler runs
out of address space on it, at `-O1` as much as at `-O2`. That matters because
interpreted, the engine takes about five times as long to produce the first
audio of an utterance as IBM's own library does (#3), and a thirty-two bit
host had no way out of it.

`tools/delta-decompile.py` now takes `--parts=N`, and the Makefile passes
`RULE_PARTS`, 16 by default.

**Shared out by size, not by count.** The rules are nothing like the same
size: dividing them evenly by count put 3.7 MB of the 13 into one file, which
is the thing this is here to avoid. By size the largest piece is 795 KB.

**What changed in the generated code.** Each piece carries the `DG_*` global
offsets, because each has rules that reach through them. The rules are
linkable rather than `static`, since the table that names them is in another
file -- and that file is the one the Makefile already knew about, now
carrying the offsets, a declaration for every rule, and the table.

`make distclean` removes the pieces. Without it a later run with fewer parts
would leave one behind to be compiled, defining its rules a second time.

**Results.** Thirty-two bit `RULES=c` builds, in 41 s with `-j8`, where before
it did not compile. Sixty-four bit drops from 4m20s to 50s, because the
pieces compile at the same time as each other.

The audio is unchanged. Identical SHA-256 over three voices and seven texts
against the single-file build, sixty-four bit; and `RULES=c` was already
verified identical to `RULES=bytecode` over the same cases.

`tools/engine_probe.c` comes with it: it takes a path to an `eci.dll` and a
line of text and prints the sample count and a checksum, built for either word
size, so a build here and IBM's own library can be asked the same question.
That is what the comparisons above and in #3 and #4 were made with.