### PR TITLE
Send settings as control steps, not as speech

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -52,6 +52,8 @@ What is left is not German's. Two of the cases with markers in them -- an audio 
 
 The NVDA add-on follows. Where the library it loads has more than one language in it, every language's eight presets are offered as voices of their own -- "German - Voice 3" -- each saying which language it is, so the reader matches a document's language to one of them; and a `LangChangeCommand` in a speech sequence switches the engine mid-utterance, so a German quotation in an English page is read as German. A library with one language in it offers what it always did, under the same names, so nothing a reader had chosen is lost.
 
+Settings are queued as control steps rather than as speech. Anything queued as speech is thrown away by a cancel that overtakes it, which is right for an utterance and wrong for a setting: every keystroke cancels, so a rate or a voice chosen at the wrong moment simply did not happen, with the dialog still showing what had been asked for.
+
 Not done for German: no dictionary in a form a person can edit, since `tools/delta-dict.py` has only been run for English, and no `long` cases.
 
 ## British English

--- a/nvda/addon/synthDrivers/_openevv.py
+++ b/nvda/addon/synthDrivers/_openevv.py
@@ -266,6 +266,16 @@ class Engine:
 		"""Run these calls on the engine's thread, in this order."""
 		self._work.put((SPEECH, batch))
 
+	def control(self, batch):
+		"""The same, for something that is not speech.
+
+		A setting is asked for once and has to arrive. Queued as speech it is
+		thrown away by any cancel that overtakes it -- and since every
+		keystroke cancels, a voice or a rate chosen at the wrong moment simply
+		did not happen, with the dialog still showing what was asked for.
+		"""
+		self._work.put((CONTROL, batch))
+
 	def cancel(self):
 		"""Stop now, and throw away what has not been spoken.
 
@@ -300,16 +310,23 @@ class Engine:
 			self.player.pause(switch)
 
 	def _drain(self):
+		"""Drop the utterances that have not started, and only those.
+
+		A control step is not speech and is not silenced: it is put back in the
+		order it was in, along with the closing sentinel, which is not ours to
+		drop either.
+		"""
+		keep = []
 		while True:
 			try:
 				item = self._work.get_nowait()
 			except queue.Empty:
-				return
+				break
 			self._work.task_done()
-			if item is None:
-				# Closing down: put it back, it is not ours to drop.
-				self._work.put(None)
-				return
+			if item is None or item[0] == CONTROL:
+				keep.append(item)
+		for item in keep:
+			self._work.put(item)
 
 	# ---- the calls themselves, all on this thread --------------------
 

--- a/nvda/addon/synthDrivers/openevv.py
+++ b/nvda/addon/synthDrivers/openevv.py
@@ -295,7 +295,7 @@ class SynthDriver(SynthDriver):
 		self._abbreviations = enable
 		# Nought turns the abbreviation dictionary on, which is the engine's
 		# own sense of the setting and not a mistake here.
-		self._engine.post(
+		self._engine.control(
 			[(self._engine.setParam, (_openevv.PARAM_DICTIONARY, 0 if enable else 1))],
 		)
 
@@ -404,10 +404,14 @@ class SynthDriver(SynthDriver):
 		if language != self._engine.language:
 			batch.append((self._engine.setLanguage, (language,)))
 		batch.append((self._engine.copyVoice, (number,)))
-		self._engine.post(batch)
+		self._engine.control(batch)
 
 	def _get_language(self):
 		return _openevv.localeOf(self._engine.language)
 
 	def _post(self, which, value):
-		self._engine.post([(self._engine.setVoiceParam, (which, value))])
+		# As a control step, not as speech: a setting asked for while speech is
+		# being cancelled -- which every keystroke does -- would otherwise be
+		# thrown away with the utterances, and the reader's choice would not
+		# take.
+		self._engine.control([(self._engine.setVoiceParam, (which, value))])

--- a/nvda/test/engine.py
+++ b/nvda/test/engine.py
@@ -205,6 +205,33 @@ def engine_module(dll, player_box, library_there=True):
     return mod
 
 
+def control_checks():
+    """A setting is not speech and is not thrown away with it."""
+    dll = FakeDll()
+    players = []
+    mod = engine_module(dll, players)
+
+    engine = mod.Engine(lambda index: None)
+    engine.open()
+
+    engine.post([(engine.addText, (b"spoken",))])
+    engine.control([(engine.setParam, (mod.PARAM_DICTIONARY, 0))])
+    engine.post([(engine.addText, (b"also spoken",))])
+    engine._drain()
+
+    left = []
+    while True:
+        try:
+            left.append(engine._work.get_nowait())
+        except Exception:  # noqa: BLE001
+            break
+    check("draining for silence drops the utterances",
+          [k for k, _ in left if k == mod.SPEECH], [])
+    check("and keeps the settings",
+          len([k for k, _ in left if k == mod.CONTROL]), 1)
+    engine.close()
+
+
 def main():
     dll = FakeDll()
     players = []
@@ -392,6 +419,8 @@ def main():
     check("the thread has stopped", engine.alive(), False)
     check("the instance was given back", dll.named("eciDelete") != [], True)
     check("and the player was closed", player.closed, 1)
+
+    control_checks()
 
     # A Thread subclass shares Thread's namespace, so this holds the engine to
     # not using any name the standard library's Thread does.

--- a/nvda/test/sequence.py
+++ b/nvda/test/sequence.py
@@ -244,6 +244,8 @@ class FakeEngine:
         self.voiceParams = {0: 0, 1: 50, 2: 65, 3: 30, 4: 0, 5: 0, 6: 50, 7: 92}
         self.version = "test"
         self.player = None
+        #: Whether each batch arrived as speech or as a setting.
+        self.kinds = []
 
     def open(self):
         pass
@@ -262,6 +264,13 @@ class FakeEngine:
             if name == "setLanguage":
                 self.language = args[0]
                 self.voiceNames = self.voiceNamesByLanguage[args[0]]
+
+    def control(self, batch):
+        # A control step runs the same way as speech here; what the driver is
+        # being held to is that it sends settings as control and utterances as
+        # speech, which the check below reads off self.kinds.
+        self.kinds.append(("control", len(batch)))
+        self.post(batch)
 
     def cancel(self):
         self.calls.append(("cancel",))
@@ -504,6 +513,27 @@ def main():
     d.cancel()
     check("pausing and cancelling go straight through",
           d._engine.calls, [("pause", True), ("cancel",)])
+
+    # Every setting goes as a control step and not as speech. Sent as speech
+    # it is dropped by any cancel that overtakes it, and since every keystroke
+    # cancels, a rate or a voice chosen at the wrong moment silently did not
+    # happen -- with the dialog still showing what was asked for.
+    d._engine.kinds = []
+    d.rate = 60
+    d.pitch = 40
+    d.volume = 80
+    d.inflection = 55
+    d.headSize = 45
+    d.roughness = 10
+    d.breathiness = 20
+    d.abbreviations = True
+    d.voice = "3"
+    check("every setting is sent as a control step, never as speech",
+          [kind for kind, _ in d._engine.kinds], ["control"] * 9)
+
+    d._engine.kinds = []
+    d.speak(["a sentence"])
+    check("and an utterance still goes as speech", d._engine.kinds, [])
 
     # ---- and the same driver over a library with two languages in it ----
     #


### PR DESCRIPTION
`post()` queues as `SPEECH`, and `_drain()` throws `SPEECH` away, so every setting went through the path a cancel silences.

That is right for an utterance and wrong for a setting. Every keystroke cancels, so a rate or a voice chosen at the wrong moment simply did not happen — and the dialog went on showing what had been asked for, because the driver's own `voiceParams` cache is written only on the engine's thread, by the call that was dropped.

The `CONTROL` kind already existed for exactly this and only `_resume` used it. Settings now use it too, and `_drain` puts the control steps back in the order they were in, alongside the closing sentinel it already put back.

Affects `voice`, `rate`, `pitch`, `volume`, `inflection`, head size, roughness, breathiness and the abbreviation dictionary.

## Checks

`nvda/test/sequence.py` holds the driver to sending all nine settings as control steps and an utterance as speech. `nvda/test/engine.py` holds `_drain` to dropping the utterances and keeping the settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4Czcgx11JefDzcS9k4Yu2
