### PR TITLE
Break a stall in the wave player rather than waiting on it for ever

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -52,6 +52,8 @@ What is left is not German's. Two of the cases with markers in them -- an audio 
 
 The NVDA add-on follows. Where the library it loads has more than one language in it, every language's eight presets are offered as voices of their own -- "German - Voice 3" -- each saying which language it is, so the reader matches a document's language to one of them; and a `LangChangeCommand` in a speech sequence switches the engine mid-utterance, so a German quotation in an English page is read as German. A library with one language in it offers what it always did, under the same names, so nothing a reader had chosen is lost.
 
+A watchdog breaks a stall in the wave player. Blocking in the player is how the add-on paces synthesis -- a full player is what keeps the engine from running ahead of the speech -- but the engine is spoken to from one thread, the player has no timeout, and a player that has stopped draining looks exactly like a full one. So it held that thread, and every utterance queued behind it, saying nothing and writing nothing down; speech came back only when something else asked for silence and stopped the player as a side effect. A wait longer than five seconds where no pause was asked for is now logged, the utterance abandoned and reported finished so nothing is left waiting on a mark that is never coming. A pause the reader asked for is left alone, since a paused player is meant not to drain.
+
 Not done for German: no dictionary in a form a person can edit, since `tools/delta-dict.py` has only been run for English, and no `long` cases.
 
 ## British English

--- a/nvda/addon/synthDrivers/_openevv.py
+++ b/nvda/addon/synthDrivers/_openevv.py
@@ -53,6 +53,7 @@ import os
 import queue
 import sys
 import threading
+import time
 
 import config
 import nvwave
@@ -67,6 +68,25 @@ FRAME = 2048
 #: How much audio to gather before handing any to the player, in bytes. Small
 #: enough that speech starts promptly, large enough not to feed in dribbles.
 FEED_AT = FRAME * 2
+
+#: How long the engine's thread may sit inside the player before that is taken
+#: as a stall rather than as back pressure.
+#:
+#: Blocking in the player is the design and not a fault: a full player is what
+#: stops the engine running ahead of the speech. But there is one thread and
+#: the player has no timeout, so a player that stops draining blocks it for
+#: ever -- and with it every utterance queued behind, with nothing said to the
+#: reader and nothing written down. Speech then stays stopped until something
+#: else asks for silence and stops the player as a side effect.
+#:
+#: Longer than any buffer can honestly take to play, so back pressure never
+#: trips it: the player holds a few hundred milliseconds and this is five
+#: seconds.
+STUCK_AFTER = 5.0
+
+#: How often to look. Cheap enough to leave running and short enough that a
+#: reader notices a recovery rather than a silence.
+WATCH_EVERY = 0.5
 
 # What the callback is told.
 MSG_WAVEFORM = 0
@@ -217,6 +237,16 @@ class Engine:
 		self._pendingIndexes = []
 		self._discarding = False
 		self._produced = 0
+		#: When the engine's thread went into the player and what for, or None
+		#: when it is not in there. Written by that thread and read by the
+		#: watchdog; a stale read costs one more look round the loop.
+		self._blockedSince = None
+		self._blockedIn = ""
+		#: Whether the reader asked for the pause. A paused player does not
+		#: drain and blocking on one is meant, so the watchdog leaves it alone.
+		self._paused = False
+		self._watchdog = None
+		self._stopWatching = threading.Event()
 		self.player = None
 		self.voiceNames = {}
 		#: Every language the library has, and the one in force.
@@ -237,6 +267,10 @@ class Engine:
 		self._ready.wait()
 		if self._failure is not None:
 			raise self._failure
+		self._watchdog = threading.Thread(
+			target=self._watch, name="openevv.watchdog", daemon=True
+		)
+		self._watchdog.start()
 
 	def alive(self):
 		return self._thread.is_alive()
@@ -249,6 +283,7 @@ class Engine:
 		still running is how a screen reader ends up with a synthesiser that
 		will not speak after this one has been switched away.
 		"""
+		self._stopWatching.set()
 		self.cancel()
 		self._work.put(None)
 		self._thread.join(timeout=5)
@@ -296,6 +331,7 @@ class Engine:
 		self._work.put((CONTROL, [(self._resume, ())]))
 
 	def pause(self, switch):
+		self._paused = switch
 		if self.player is not None:
 			self.player.pause(switch)
 
@@ -428,6 +464,53 @@ class Engine:
 		self._held = bytearray()
 		self._pendingIndexes = []
 		self._discarding = False
+
+	# ---- the watchdog ------------------------------------------------
+
+	def _enteringPlayer(self, what):
+		self._blockedIn = what
+		self._blockedSince = time.monotonic()
+
+	def _leftPlayer(self):
+		self._blockedSince = None
+
+	def _watch(self):
+		"""Break a stall in the player, and say that there was one.
+
+		The engine's thread blocks in the player on purpose and usually for a
+		fraction of a second. What it cannot do is tell a full player from one
+		that has stopped taking audio, and there is no timeout to find out
+		with, so a player in the second state holds the only thread there is
+		and every utterance queued behind it. To the reader that is silence
+		with nothing in the log, lasting until something else asks for silence
+		and stops the player as a side effect.
+
+		Stopping the player is what unblocks it, which is what cancelling
+		already does, so the recovery here is the one the reader would
+		otherwise have to find. Having abandoned the utterance, whatever was
+		waiting on it is told it finished, or it waits for ever.
+		"""
+		while not self._stopWatching.wait(WATCH_EVERY):
+			since = self._blockedSince
+			# A pause is meant to stop the player draining, so blocking on one
+			# is not a stall. Nor is a wait that has not gone on long enough.
+			if since is None or self._paused:
+				continue
+			waited = time.monotonic() - since
+			if waited < STUCK_AFTER:
+				continue
+			log.error("openevv: the engine's thread has been in the player's %s"
+			          " for %.1f seconds with no pause asked for; abandoning the"
+			          " utterance so speech can go on"
+			          % (self._blockedIn, waited))
+			self._blockedSince = None
+			try:
+				self.cancel()
+			except Exception:  # noqa: BLE001
+				log.error("openevv: the stall would not clear", exc_info=True)
+			# Nobody asked for this silence, so nobody is resetting on the far
+			# side of it: say the utterance finished.
+			self._finish()
 
 	# ---- the thread --------------------------------------------------
 
@@ -611,6 +694,7 @@ class Engine:
 			del self._held[:]
 			marks = self._pendingIndexes
 			self._pendingIndexes = []
+			self._enteringPlayer("feed")
 			try:
 				if marks:
 					self.player.feed(audio, onDone=lambda m=marks: self._report(m))
@@ -619,6 +703,8 @@ class Engine:
 			except Exception:  # noqa: BLE001
 				log.error("openevv: a buffer would not play", exc_info=True)
 				self._report(marks)
+			finally:
+				self._leftPlayer()
 		else:
 			# A mark with no audio in front of it still has to be reported, or
 			# whatever is waiting on it waits for ever.
@@ -629,10 +715,13 @@ class Engine:
 		# nothing in hand, and saying it is finished before the last buffer has
 		# played cuts the next one in over it.
 		if last:
+			self._enteringPlayer("idle")
 			try:
 				self.player.idle()
 			except Exception:  # noqa: BLE001
 				log.debugWarning("openevv: the player would not go idle", exc_info=True)
+			finally:
+				self._leftPlayer()
 
 	def _reportIndexes(self):
 		marks = self._pendingIndexes

--- a/nvda/test/engine.py
+++ b/nvda/test/engine.py
@@ -205,6 +205,137 @@ def engine_module(dll, player_box, library_there=True):
     return mod
 
 
+def stall_checks():
+    """A player that stops taking audio must not silence the synthesiser.
+
+    Blocking in the player is the design: a full one is what keeps the engine
+    from running ahead of the speech. But there is one thread, the player has
+    no timeout, and a player that has stopped draining is indistinguishable
+    from a full one -- so it holds that thread, and every utterance behind it,
+    with nothing said and nothing written down.
+    """
+    import threading
+    import time
+
+    class DeadPlayer:
+        """Drains until told not to, and then never again."""
+
+        def __init__(self, **kwargs):
+            self.made = kwargs
+            self.lock = threading.Condition()
+            self.queued = []
+            self.dead = False
+            self.stopped = 0
+            self.closed = 0
+            self.paused = []
+            threading.Thread(target=self._drain, daemon=True).start()
+
+        def _drain(self):
+            while True:
+                with self.lock:
+                    if self.queued and not self.dead:
+                        _, onDone = self.queued.pop(0)
+                        self.lock.notify_all()
+                    else:
+                        onDone = None
+                if onDone:
+                    onDone()
+                time.sleep(0.002)
+
+        def feed(self, data, size=None, onDone=None):
+            with self.lock:
+                while len(self.queued) >= 3:
+                    self.lock.wait(timeout=30)
+                self.queued.append((bytes(data), onDone))
+
+        def idle(self):
+            with self.lock:
+                while self.queued:
+                    self.lock.wait(timeout=30)
+
+        def stop(self):
+            with self.lock:
+                self.queued = []
+                self.dead = False
+                self.stopped += 1
+                self.lock.notify_all()
+
+        def pause(self, switch):
+            self.paused.append(switch)
+
+        def close(self):
+            self.closed += 1
+
+        def sync(self):
+            pass
+
+    dll = FakeDll()
+    players = []
+    mod = engine_module(dll, players)
+    import nvwave
+
+    nvwave.WavePlayer = lambda **kw: players.append(DeadPlayer(**kw)) or players[-1]
+    mod.nvwave = nvwave
+    # The same logic on a shorter fuse, so the check is quick.
+    mod.STUCK_AFTER = 1.0
+    mod.WATCH_EVERY = 0.2
+
+    def synchronize(handle):
+        for _ in range(30):
+            dll.callback(handle, mod.MSG_WAVEFORM, 1024, None)
+        return 1
+
+    dll.answer_synchronize = synchronize
+
+    done = []
+    engine = mod.Engine(lambda index: done.append(index))
+    engine.open()
+    player = players[0]
+
+    def utterance():
+        return [(engine.addText, (b"x",)), (engine.synthesize, (True,))]
+
+    engine.post(utterance())
+    time.sleep(0.8)
+    check("speech reaches the player to begin with", done.count(None), 1)
+
+    del done[:]
+    with player.lock:
+        player.dead = True
+    for _ in range(4):
+        engine.post(utterance())
+    time.sleep(0.8)
+    check("a player that stops draining holds the thread and the queue",
+          (done.count(None), engine._work.qsize() > 0), (0, True))
+
+    time.sleep(2.5)
+    check("the stall is broken rather than waited out", player.stopped >= 1, True)
+    check("and whatever waited on the utterance is told it finished",
+          done.count(None) >= 1, True)
+    check("and the utterances behind it are not left queued",
+          engine._work.qsize(), 0)
+
+    del done[:]
+    engine.post(utterance())
+    time.sleep(1.2)
+    check("speech works again without the reader having to interrupt",
+          done.count(None), 1)
+
+    # A pause is meant to stop the player draining, so it is not a stall and
+    # must not be broken: doing so would resume speech the reader paused.
+    del done[:]
+    engine.pause(True)
+    with player.lock:
+        player.dead = True
+    before = player.stopped
+    engine.post(utterance())
+    time.sleep(2.5)
+    check("but a pause the reader asked for is left alone",
+          (player.stopped, done.count(None)), (before, 0))
+    engine.pause(False)
+    engine.cancel()
+
+
 def main():
     dll = FakeDll()
     players = []
@@ -392,6 +523,8 @@ def main():
     check("the thread has stopped", engine.alive(), False)
     check("the instance was given back", dll.named("eciDelete") != [], True)
     check("and the player was closed", player.closed, 1)
+
+    stall_checks()
 
     # A Thread subclass shares Thread's namespace, so this holds the engine to
     # not using any name the standard library's Thread does.


### PR DESCRIPTION
Blocking in NVDA's wave player is the design, and the file says so: a full player is what keeps the engine from running ahead of the speech.

But the engine is spoken to from one thread, `WavePlayer.feed` and `WavePlayer.idle` have no timeout, and a player that has **stopped** draining is indistinguishable from one that is merely full. So it holds that thread and every utterance queued behind it. No `done` is reported either, so whatever was waiting on the utterance waits for ever, and `_resume` never runs because it is queued behind the block. Speech returns only when something else happens to ask for silence and stops the player as a side effect.

A watchdog now breaks a wait longer than five seconds where no pause was asked for. Stopping the player is what unblocks it, which is what `cancel` already does, so the recovery is the one the reader would otherwise have to find by hand. The utterance is abandoned and reported finished, since nobody asked for that silence and nothing is resetting on the far side of it.

A pause the reader asked for is left alone: a paused player is meant not to drain, and breaking that would resume speech they had stopped.

The threshold is far longer than any buffer can honestly take to play — the player holds a few hundred milliseconds — so back pressure never trips it.

This is defence in depth rather than a fix for a fault seen in the wild: I could not make a real `WasapiWavePlayer` stall on demand, so the check drives a player that stops draining. If you would rather the layer simply blocked, this is the one of the three to drop.

## Checks

`nvda/test/engine.py` grows a player that stops draining, and holds the layer to: the stall being broken rather than waited out, whatever waited on the utterance being told it finished, the queue behind it not being left stranded, speech working again without the reader interrupting, and a pause **not** being broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4Czcgx11JefDzcS9k4Yu2
