### PR TITLE
Read a dictionary in from a file, and write one out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ ALL_CFLAGS := $(OPT) -std=gnu99 $(INCS) $(WARN) $(LOW) $(TRIM) \
 OBJDIR  := $(BUILD)/obj-$(RULES)/$(subst $(space),-,$(TAGS))
 OBJECTS := $(patsubst %.c,$(OBJDIR)/%.o,$(notdir $(SOURCES)))
 
-.PHONY: all probe rules missing install clean evv32 probe32 instances interrupt landing rate inikeys stopthread
+.PHONY: all probe rules missing install clean evv32 probe32 instances interrupt landing rate dict inikeys stopthread
 all: $(BUILD)/evv
 
 $(BUILD)/evv: cli/evv.c $(BUILD)/libevv$(SUF).a $(RULESTAMP)
@@ -252,6 +252,17 @@ rate: $(BUILD)/rate
 
 $(BUILD)/rate: test/rate.c $(BUILD)/libevv.a
 	@$(CC) $(ALL_CFLAGS) test/rate.c $(BUILD)/libevv.a -lpthread -lm -o $@
+	@echo "built $@"
+
+# A dictionary read in from a file, which nothing else here does: probe.c
+# makes one and puts it in force but never loads one, and the reference
+# answered the same refusal from the same stub, so both sides agreed while
+# eciLoadDict did nothing at all.
+dict: $(BUILD)/dict
+	@cd $(BUILD) && ./dict
+
+$(BUILD)/dict: test/dict.c $(BUILD)/libevv.a
+	@$(CC) $(ALL_CFLAGS) test/dict.c $(BUILD)/libevv.a -lpthread -lm -o $@
 	@echo "built $@"
 
 # A backtrack landed on from a thread that never planted it, which is how

--- a/src/eci_dict.c
+++ b/src/eci_dict.c
@@ -10,8 +10,9 @@
    so the family-nought slot is never touched by anything here and the queue
    has it to itself.
 
-   Loading a dictionary from a file and saving one to a file were published
-   and never written; both answer that they could not.
+   Loading a dictionary from a file and saving one to a file go through to
+   the volume calls the newer interface has, which the layer below has always
+   implemented.
 
    Names are prefixed and the aliases at the foot carry the real ones. */
 
@@ -67,6 +68,12 @@ extern int32_t STDCALL api_get_active_dict(void *h2, int32_t lang,
 extern int32_t STDCALL api_get_dict_language(void *h2, void *dict,
                                              int32_t *lang)
     MANGLED("_eciGetDictLanguage2@12");
+extern int32_t STDCALL api_load_dict_volume(void *h2, void *dict,
+                                            int32_t volume, const char *name)
+    MANGLED("_eciLoadDictVolume2@16");
+extern int32_t STDCALL api_save_dict_volume(void *h2, void *dict,
+                                            int32_t volume, const char *name)
+    MANGLED("_eciSaveDictVolume2@16");
 extern int32_t STDCALL eo_getParam(OldInst *h, int32_t which)
     MANGLED("_eciGetParam@8");
 
@@ -212,26 +219,59 @@ int STDCALL ed_deleteDict(OldInst *h, void *dict)
     return 0;
 }
 
-/* Reading a dictionary from a file and writing one to a file were published
-   and never written. */
+/* Read a dictionary in from a file, or write one out.
+
+   These two were published and left unwritten, answering that they could not
+   whatever they were handed -- so a caller with a file of pronunciations had
+   no way in at all, since the per-entry calls are not exported by the older
+   interface either. The work itself was never missing: eciLoadDictVolume and
+   eciSaveDictVolume on the newer interface reach the engine's own volume
+   loader, and the user dictionary underneath them reads and writes the file
+   format already. All that was absent is the crossing between the two, which
+   is what these are.
+
+   The volume is the caller's `kind', unchanged: the numbering is the same on
+   both sides, and the layer below is what decides which of them it has.
+
+   Everything queued is spoken and waited for first, for the reason ed_newDict
+   gives -- a dictionary changes how words are said, so anything already on
+   its way has to come out under the rules it was queued under. And an engine
+   in the middle of speaking is refused rather than made to wait, which is
+   what every other entry point here does. */
+static int ed_volume(OldInst *h, void *dict, int32_t kind, const char *name,
+                     int saving)
+{
+    OldInst *inst = h;
+    int32_t rc;
+
+    if (!h || !dict || !name)
+        return DICT_NOT_SUPPORTED;
+
+    if (api_check_synth(OI_NEW(inst)) == SYNTH_BUSY) {
+        OI_REFUSED(inst) = 0x2000;
+        OI_REFUSEDALL(inst) |= 0x2000;
+        return DICT_NOT_SUPPORTED;
+    }
+
+    ev_sendParameters(inst);
+    api_synthesize(OI_NEW(inst));
+    api_synchronize(OI_NEW(inst));
+
+    rc = saving ? api_save_dict_volume(OI_NEW(inst), dict, kind, name)
+                : api_load_dict_volume(OI_NEW(inst), dict, kind, name);
+    return ed_rc_to_ECIDictError(rc);
+}
+
 int STDCALL ed_loadDict(OldInst *h, void *dict, int32_t kind,
                           const char *name)
 {
-    (void)h;
-    (void)dict;
-    (void)kind;
-    (void)name;
-    return DICT_NOT_SUPPORTED;
+    return ed_volume(h, dict, kind, name, 0);
 }
 
 int STDCALL ed_saveDict(OldInst *h, void *dict, int32_t kind,
                           const char *name)
 {
-    (void)h;
-    (void)dict;
-    (void)kind;
-    (void)name;
-    return DICT_NOT_SUPPORTED;
+    return ed_volume(h, dict, kind, name, 1);
 }
 
 ALIAS("?rc_to_ECIDictError@@YA?AW4ECIDictError@@J@Z",

--- a/test/dict.c
+++ b/test/dict.c
@@ -1,0 +1,242 @@
+/* Read a dictionary in from a file and hear that it took.
+ *
+ * eciLoadDict and eciSaveDict were published and left unwritten: both
+ * answered eciDictNotSupported whatever they were handed. Nothing in the
+ * suite could see that, because nothing in the suite loads a dictionary --
+ * cli/probe.c walks the dictionary layer far enough to make one, put it in
+ * force and take it away again, and the reference answers the same refusal
+ * from the same stub, so both sides agreed. A caller with a file of
+ * pronunciations had no way in at all, since the per-entry calls are not
+ * exported by the older interface either.
+ *
+ * Three things are checked. Loading has to answer that it worked. The word
+ * the dictionary names has to come out different from the way it comes out
+ * without it. And saving has to write the entry back.
+ *
+ * The second is the one that matters, and it is why this speaks twice rather
+ * than once: a dictionary that is merely made and put in force changes the
+ * audio on its own, so holding a run with a dictionary against a run without
+ * one proves nothing. Both runs here load a dictionary and differ only in
+ * whether it names the word being spoken.
+ *
+ * usage: dict
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+#include "evv_abi.h"
+
+enum { FRAME = 1024 };
+
+/* eciMainDict, and what the older interface answers for success. */
+enum { VOLUME_MAIN = 0, DICT_OK = 0 };
+
+typedef struct OldInst OldInst;
+
+enum ECIMessage { eciWaveformBuffer, eciPhonemeBuffer, eciIndexReply };
+enum ECICallbackReturn { eciDataNotProcessed, eciDataProcessed, eciDataAbort };
+
+OldInst *STDCALL eo_newEx(int32_t language);
+int      STDCALL es_delete(OldInst *h);
+int      STDCALL et_addText(OldInst *h, const char *text);
+int      STDCALL et_synthesize(OldInst *h);
+int      STDCALL ev_setOutputBuffer(OldInst *h, int32_t n, void *buf);
+void     STDCALL eo_registerCallback(OldInst *h, void *cb, void *data);
+void     STDCALL eo_synchronizeSynth(OldInst *h);
+int      STDCALL eo_speaking(OldInst *h);
+int      STDCALL eo_getAvailableLanguages(uint32_t *out, int *count);
+void    *STDCALL ed_newDict(OldInst *h);
+int      STDCALL ed_setDict(OldInst *h, void *dict);
+int      STDCALL ed_deleteDict(OldInst *h, void *dict);
+int      STDCALL ed_loadDict(OldInst *h, void *dict, int32_t kind,
+                             const char *name);
+int      STDCALL ed_saveDict(OldInst *h, void *dict, int32_t kind,
+                             const char *name);
+void evvRunStaticInitialisers(void);
+void evv_port_start(void);
+void evv_port_finish(void);
+
+static short frame[FRAME];
+static long  said;
+
+static enum ECICallbackReturn STDCALL on_message(OldInst *h,
+                                                 enum ECIMessage msg,
+                                                 long param, void *data)
+{
+    (void)h;
+    (void)data;
+    if (msg == eciWaveformBuffer)
+        said += param;
+    return eciDataProcessed;
+}
+
+static void nap(long ms)
+{
+#if defined(_WIN32)
+    Sleep((DWORD)ms);
+#else
+    struct timespec t;
+
+    t.tv_sec = ms / 1000;
+    t.tv_nsec = (ms % 1000) * 1000000L;
+    nanosleep(&t, NULL);
+#endif
+}
+
+/* A dictionary file of one entry. A file's last line is dropped on the way
+   past the end of it, so there is a blank one after the entry. */
+static int write_dict(const char *path, const char *word, const char *say_as)
+{
+    FILE *f = fopen(path, "wb");
+
+    if (!f)
+        return 0;
+    fprintf(f, "%s\t%s\n\n", word, say_as);
+    fclose(f);
+    return 1;
+}
+
+/* Speak one word through a dictionary read in from *path*. Answers how many
+   samples came back, or -1 where it would not play at all. */
+static long say_through(uint32_t language, const char *path, int *loaded)
+{
+    OldInst *h = eo_newEx(language);
+    void    *dict;
+    long     was;
+    int      i;
+
+    *loaded = -1;
+    if (!h)
+        return -1;
+
+    eo_registerCallback(h, (void *)on_message, 0);
+    if (!ev_setOutputBuffer(h, FRAME, frame)) {
+        es_delete(h);
+        return -1;
+    }
+
+    dict = ed_newDict(h);
+    if (!dict) {
+        es_delete(h);
+        return -1;
+    }
+
+    *loaded = ed_loadDict(h, dict, VOLUME_MAIN, path);
+    ed_setDict(h, dict);
+
+    was = said;
+    if (!et_addText(h, "nvda") || !et_synthesize(h)) {
+        es_delete(h);
+        return -1;
+    }
+    /* Nothing drains the engine's message queue by itself; asking whether it
+       is still speaking is what pumps it. */
+    for (i = 0; i < 3000 && eo_speaking(h); i++)
+        nap(10);
+    eo_synchronizeSynth(h);
+
+    ed_setDict(h, 0);
+    ed_deleteDict(h, dict);
+    es_delete(h);
+    return said - was;
+}
+
+int main(void)
+{
+    const char *named   = "dict-named.txt";
+    const char *other   = "dict-other.txt";
+    const char *written = "dict-written.txt";
+    uint32_t    langs[32];
+    int         n = 32;
+    int         loadedNamed = -1, loadedOther = -1, bad = 0;
+    long        withEntry, withoutEntry;
+    OldInst    *h;
+    void       *dict;
+    char        back[256];
+    FILE       *f;
+
+    evv_port_start();
+    evvRunStaticInitialisers();
+
+    if (eo_getAvailableLanguages(langs, &n) || n < 1) {
+        printf("dict: no language\n");
+        return 1;
+    }
+
+    if (!write_dict(named, "nvda", "enn vee dee ay")
+        || !write_dict(other, "xyzzynothing", "foo")) {
+        printf("dict: could not write the dictionaries\n");
+        return 1;
+    }
+
+    withoutEntry = say_through(langs[0], other, &loadedOther);
+    withEntry    = say_through(langs[0], named, &loadedNamed);
+
+    if (loadedOther != DICT_OK || loadedNamed != DICT_OK) {
+        printf("dict: loading answered %d and %d, wanted %d\n",
+               loadedOther, loadedNamed, DICT_OK);
+        bad = 1;
+    }
+    if (withoutEntry <= 0 || withEntry <= 0) {
+        printf("dict: one of the runs said nothing at all (%ld, %ld)\n",
+               withoutEntry, withEntry);
+        bad = 1;
+    } else if (withoutEntry == withEntry) {
+        printf("dict: the entry changed nothing -- both runs answered %ld"
+               " samples, so the dictionary was not read\n", withEntry);
+        bad = 1;
+    } else {
+        printf("dict: %ld samples without the entry, %ld with it\n",
+               withoutEntry, withEntry);
+    }
+
+    /* And back out to a file again. */
+    h = eo_newEx(langs[0]);
+    if (h) {
+        eo_registerCallback(h, (void *)on_message, 0);
+        ev_setOutputBuffer(h, FRAME, frame);
+        dict = ed_newDict(h);
+        if (dict) {
+            if (ed_loadDict(h, dict, VOLUME_MAIN, named) != DICT_OK
+                || ed_saveDict(h, dict, VOLUME_MAIN, written) != DICT_OK) {
+                printf("dict: saving would not answer that it worked\n");
+                bad = 1;
+            } else {
+                back[0] = 0;
+                f = fopen(written, "rb");
+                if (f) {
+                    size_t got = fread(back, 1, sizeof back - 1, f);
+
+                    back[got] = 0;
+                    fclose(f);
+                }
+                if (strstr(back, "nvda") == 0) {
+                    printf("dict: what was written back has no entry in it\n");
+                    bad = 1;
+                }
+            }
+            ed_deleteDict(h, dict);
+        }
+        es_delete(h);
+    }
+
+    remove(named);
+    remove(other);
+    remove(written);
+    evv_port_finish();
+
+    if (bad)
+        return 1;
+    printf("dict: a dictionary read in from a file changes how a word is"
+           " said, and writes back out again\n");
+    return 0;
+}


### PR DESCRIPTION
## The fault

`eciLoadDict` and `eciSaveDict` were published in 1998 and never written: both answered `eciDictNotSupported` whatever they were handed. A caller with a file of pronunciations had no way in at all, since the per-entry calls (`eciUpdateDict`, `eciUpdateDictExt`, `eciAddDictEntry`) are not exported by the older interface either.

Nothing in the suite could see that, because nothing in the suite loads a dictionary — `cli/probe.c` walks the dictionary layer far enough to make one, put it in force and take it away again, and the reference answers the same refusal from the same stub, so both sides agreed.

## The change

The work itself was never missing: `eciLoadDictVolume` and `eciSaveDictVolume` on the newer interface reach the engine's own volume loader, and the user dictionary underneath them already reads and writes the file format. All that was absent is the crossing between the two, which is what this adds — a single `ed_volume` helper behind both published names, passing the caller's `kind` through as the volume, since the numbering is the same on both sides.

Everything queued is spoken and waited for first, for the reason `ed_newDict` gives — a dictionary changes how words are said, so anything already on its way has to come out under the rules it was queued under. And an engine in the middle of speaking is refused rather than made to wait, which is what every other entry point here does.

## Checks

`make dict` (new, `test/dict.c`, in the style of `test/rate.c`) loads a dictionary of one entry through the file route and speaks the word it names, twice over: once through a dictionary that names the word and once through one that does not, because a dictionary that is merely made and put in force changes the audio on its own, so holding a run with a dictionary against a run without one proves nothing. It checks that loading answers that it worked, that the entry changes how the word is said, and that saving writes the entry back.

Verified in both directions:

- with the fix: loading answers 0 both runs, 10175 samples without the entry against 14575 with it, and the entry comes back out of `eciSaveDict`.
- sabotaged (`ed_volume` returning `DICT_NOT_SUPPORTED` again): loading answers 6 and 6, saving refuses, `make dict` fails. Restored and re-run clean afterwards.

`make missing RULES=bytecode` still answers zero, so the two new volume calls have not gone back to IBM's objects.
