### PR TITLE
Resolve an address in the store it is inside before the store it ends

### DIFF
--- a/src/delta/delta_low.c
+++ b/src/delta/delta_low.c
@@ -100,7 +100,12 @@ void delta_low_region(const void *at, size_t bytes)
    stopping for rather than a value that will be wrong later.
 
    One past the end of a store counts as inside it, because a rule may name
-   the byte after a string. */
+   the byte after a string -- but only after every store has been asked
+   whether the address is properly inside it. Where the linker puts two stores
+   next to each other the first byte of the second is also one past the end of
+   the first, and answering with whichever was registered first hands back a
+   pointer just past that store's copy instead of the copy of the store the
+   address is in. */
 void *delta_low_at(const void *p)
 {
     const unsigned char *c = p;
@@ -110,8 +115,15 @@ void *delta_low_at(const void *p)
         return 0;
 
     for (i = 0; i < regions; i++)
-        if (c >= region[i].at && c <= region[i].at + region[i].bytes)
+        if (c >= region[i].at && c < region[i].at + region[i].bytes)
             return region[i].copy + (c - region[i].at);
+
+    /* Only now the byte after a store, because an address that is one past the
+       end of one store and inside another belongs to the one it is inside, and
+       the linker is free to put two stores next to each other. */
+    for (i = 0; i < regions; i++)
+        if (c == region[i].at + region[i].bytes)
+            return region[i].copy + region[i].bytes;
 
     fprintf(stderr, "evv: %p is in the program and in none of the stores"
             " copied out of it\n", p);


### PR DESCRIPTION
`delta_low_at` translates an address in the program to the address of that store's copy in the arena, and it counts one past the end of a store as inside it, because a rule may name the byte after a string. It does that in the same pass as the ordinary case, so the first store to match wins.

Where the linker puts two stores next to each other, the first byte of the second store is also one past the end of the first. Whichever of the two was registered first then claims the address, and what comes back is a pointer just past that store's copy in the arena rather than the copy of the store the address is actually in. The bytes there belong to whatever the arena allocator put next, so the rule reads a constant that was never its own.

Nothing shows on x86, where this engine's stores do not land adjacently. On aarch64 they do.

## What it costs on aarch64

The engine speaks most text with different samples, speaks nothing whatever for some ordinary words, and faults in the pitch rules on others.

```
                                       x86      aarch64   aarch64
                                                (before)  (after)
"One."                                 18546     15598     18546
"six."                                 19888     18898     19888
"seven."                               21208         0     21208
"eight."                               16346         0     16346
"The cafe in Prague is open today."    54362     12980     54362
```

Bytes of PCM at 11,025 Hz. `"seven."` and `"eight."` give a wave file with a header and no samples in it. The fault on other text is a null node reference in `visleft`, reached through `evv_phr_initial_F0` → `enus_valid_f0_posn` → `dur_expr`.

## The fix

Ask every store whether the address is properly inside it, and only then allow the byte after one. An address one past the end of one store and inside another belongs to the one it is inside.

## Verified

`test/matrix.sh check enus`, against the baselines recorded on x86, so both hashes are compared — the samples and the answers the probe reported:

| | before | after |
| --- | --- | --- |
| aarch64 | 98 of 98 cases moved | **none moved** |
| x86 | none moved | **none moved** |

The x86 column is what says this costs the working platform nothing. Both are `RULES=bytecode`; the 32-bit builds are unaffected either way, since the arena and this translation are compiled out where a pointer already fits a value.

I could only run `enus`: the aarch64 side is `cli/probe.c` built with the NDK and driven on a device over adb, which I did with a shim standing in for the probe so `test/matrix.sh` could drive it unchanged. Happy to run more languages, or the C rules as well as the bytecode, if that would help.

## How it was found

Building `cli/probe.c` for aarch64, running it on the device beside a desktop build of the same source, and diffing `DELTA_RULE_TRACE`. The two agree on which rules run and disagree from the second rule on what they answer, with `ZZfence_null` giving `0000000a` on x86 and an arena address on aarch64.

Context: this came out of getting the engine onto Android as a TalkBack speech engine. As far as I can tell openevv has only ever been built on x86 — CI is Ubuntu and Windows on x86, and the flake pins `x86_64-linux` — so this is the first aarch64 build rather than a regression.
